### PR TITLE
Disable the 'flying' option on boards with fewer than 3 rings.

### DIFF
--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -13,7 +13,7 @@ public class GameManager : Singleton<GameManager>
 
 
     // Play the background melody on loop with specified volume and pitch
-    private void Awake() => AudioManager.PlayFromResources(Sounds.Melody, 0.2f, 1, true);
+    private void Awake() => AudioManager.PlayFromResources(Sounds.Melody, 0.3f, 1, true);
 
 
     // Loads the game board and pieces

--- a/Assets/Scripts/Managers/MenuManager.cs
+++ b/Assets/Scripts/Managers/MenuManager.cs
@@ -47,7 +47,7 @@ public class MenuManager : Singleton<MenuManager>
             return;
 
         // Instantiate the transition object from Resources and destroy it after 2 seconds
-        AudioManager.PlayFromResources(Sounds.Melody, 0.2f, 1, true);
+        AudioManager.PlayFromResources(Sounds.Melody, 0.3f, 1, true);
 
         _transitionObj = Instantiate(Resources.Load<GameObject>("Menu/Transition"));
         Destroy(_transitionObj, 2);
@@ -86,8 +86,19 @@ public class MenuManager : Singleton<MenuManager>
     /// <param name="value">The state of the background melody (true = muted, false = unmuted)</param>
     public void MelodyDisable(bool value)
     {
-        GameObject.Find("Melody").GetComponent<AudioSource>().mute = value;
-        _melodyDisable = value;
+        GameObject melody = GameObject.Find("Melody");
+        if (melody != null)
+        {
+            GameObject.Find("Melody").GetComponent<AudioSource>().mute = value;
+            _melodyDisable = value;
+        }
+        else
+        {
+            if(value)
+            {
+                AudioManager.PlayFromResources(Sounds.Melody, 0.3f, 1, true);
+            }
+        }
     }
 
     // Opens the settings menu by instantiating a settings popup

--- a/Assets/Scripts/Piece/PieceController.cs
+++ b/Assets/Scripts/Piece/PieceController.cs
@@ -1,8 +1,7 @@
 ﻿using System.Collections.Generic;
-using TMPro;
-using UnityEngine;
-using UnityEngine.SceneManagement;
 using UnityEngine.UI;
+using UnityEngine;
+using TMPro;
 
 public class PieceController
 {

--- a/Assets/Scripts/Piece/PieceMovement.cs
+++ b/Assets/Scripts/Piece/PieceMovement.cs
@@ -61,7 +61,7 @@ public class PieceMovement
     /// </summary>
     private bool IsPathClear(Vector3 start, Vector3 end, Player player)
     {
-        if (player.piecesOnBoard + player.remainingPieces == 3)
+        if (player.piecesOnBoard + player.remainingPieces == 3 && _numberOfRings >= 3)
         {
             return true;
         }
@@ -132,22 +132,21 @@ public class PieceMovement
     /// </summary>
     private IEnumerator AnimateMovement(GameObject selectedPiece, Vector3 targetPosition, HashSet<Vector3> occupiedPositions, System.Action onMillDetected, System.Action onSwitchPlayer, PieceMillDetector lineDetector)
     {
-        _pieceMoving = true; // Mark the piece as moving
-        float speed = 5f;
-        float distance = Vector3.Distance(selectedPiece.transform.position, targetPosition); // Distance to move
-        float duration = distance / speed;
-        float elapsedTime = 0f;
+        _pieceMoving = true;
+        float animationDuration = 0.5f; // Constant duration for the movement
 
         AudioManager.PlayFromResources(Sounds.PieceMove, 0.15f, 1.2f);
 
         Vector3 startingPosition = selectedPiece.transform.position; // Starting position of the piece
         occupiedPositions.Remove(startingPosition); // Remove old position from occupied
-        lineDetector.RemoveOwner(selectedPiece.transform.position);
+        lineDetector.RemoveOwner(startingPosition);
 
-        while (elapsedTime < duration)
+        float elapsedTime = 0f;
+
+        while (elapsedTime < animationDuration)
         {
             elapsedTime += Time.deltaTime; // Increment elapsed time
-            float t = elapsedTime / duration; // Calculate interpolation factor
+            float t = elapsedTime / animationDuration; // Calculate interpolation factor
             selectedPiece.transform.position = Vector3.Lerp(startingPosition, targetPosition, t); // Move piece
             yield return null;
         }
@@ -157,7 +156,7 @@ public class PieceMovement
         lineDetector.SetOwner(targetPosition, selectedPiece.name);
 
         onSwitchPlayer.Invoke();
-        
+
         // Check if moving to this position creates a mill
         if (_lineDetector.IsMill(targetPosition, selectedPiece.name, occupiedPositions))
         {
@@ -171,7 +170,7 @@ public class PieceMovement
         }
 
         DeselectCurrentPiece(selectedPiece);
-        _pieceMoving = false; // Mark movement as complete
+        _pieceMoving = false;
     }
 
     /// <summary>


### PR DESCRIPTION
Flying is only enabled on boards with 3 or more rings. Additionally, fixed piece animations so that movement speed remains consistent regardless of distance.